### PR TITLE
change cmake to use find_package over find_library and fixed confusion of sizeof(void)

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -7,6 +7,6 @@
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project(PSP2_FIXUP)
 
-find_library(OpenSSL REQUIRED)
+find_package(OpenSSL REQUIRED)
 
 add_subdirectory(psp2-fixup)

--- a/tools/psp2-fixup/scn.h
+++ b/tools/psp2-fixup/scn.h
@@ -18,7 +18,7 @@ typedef struct {
 	Elf32_Word orgSize;
 	Elf32_Half phndx;
 	Elf32_Word segOffset;
-	void *content;
+	char *content;
 	Elf32_Shdr shdr;
 } scn_t;
 


### PR DESCRIPTION
find_package will also find the header files in addition to the library files. GCC automatically assumes that "sizeof(void) == 1" which causes compilation issues on MSVC.